### PR TITLE
Add repository section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   "keywords": [],
   "author": "Steve Konves",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/skonves/openapi-router.git"
+  },
   "devDependencies": {
     "@types/chai": "^4.1.3",
     "@types/mocha": "^5.2.0",


### PR DESCRIPTION
This enables linking from the npm website to the github repository.