### PR TITLE
Type arrays

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -123,14 +123,7 @@ export namespace OpenAPI {
         in: 'query' | 'header' | 'path' | 'formData';
         description?: string;
         required?: boolean;
-        type:
-          | 'string'
-          | 'number'
-          | 'integer'
-          | 'boolean'
-          | 'array'
-          | 'file'
-          | 'object'; // TODO: verify that object is valid
+        type: PropertyType;
         format?: string;
         allowEmptyValue?: boolean;
         items?: Items;
@@ -154,14 +147,7 @@ export namespace OpenAPI {
 
   export type Header = {
     description?: string;
-    type:
-      | 'string'
-      | 'number'
-      | 'integer'
-      | 'boolean'
-      | 'array'
-      | 'file'
-      | 'object'; // TODO: verify that object is valid
+    type: PropertyType;
     format?: string;
     items?: Items;
     collectionFormat?: 'csv' | 'ssv' | 'tsv' | 'pipes' | 'multi';
@@ -176,14 +162,7 @@ export namespace OpenAPI {
   };
 
   export type Items = {
-    type:
-      | 'string'
-      | 'number'
-      | 'integer'
-      | 'boolean'
-      | 'array'
-      | 'file'
-      | 'object'; // TODO: verify that object is valid
+    type: PropertyType;
     format?: string;
     items?: Items;
     collectionFormat?: 'csv' | 'ssv' | 'tsv' | 'pipes' | 'multi';
@@ -290,4 +269,15 @@ export namespace OpenAPI {
   };
 
   export type JsonSchema = any;
+
+  export type TypePrimitive =
+    | 'string'
+    | 'number'
+    | 'integer'
+    | 'boolean'
+    | 'array'
+    | 'file'
+    | 'object'; // TODO: verify that object is valid
+
+  export type PropertyType = TypePrimitive | [TypePrimitive];
 }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -260,7 +260,16 @@ function preCast(
 ): any {
   if (isParameter(definition) && definition.in === 'body') return value;
 
-  switch (definition.type) {
+  let typePrimitive: OpenAPI.TypePrimitive;
+  if (Array.isArray(definition.type)) {
+    typePrimitive = definition.type[0];
+    console.warn(
+      `Found type array. Defaulting to first type '${typePrimitive}'. See https://github.com/skonves/openapi-router/issues/9`,
+    );
+  } else {
+    typePrimitive = definition.type;
+  }
+  switch (typePrimitive) {
     case 'array': {
       let values;
 


### PR DESCRIPTION
Adds partial support for specs that contain property types defined as arrays.

Example:
```
{
  "type": ["string", "null"]
}
```

With these changes, `preCast` defaults to the first type in the array.  Complex objects are natively handled by `jsonschema` so "sub-parameters" are validated/cast correctly.

see #9 